### PR TITLE
Add feature to skip upgrade if no changes detected

### DIFF
--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: dev-cluster
+context: minikube
 locked: false

--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: minikube
+context: dev-cluster
 locked: false

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,6 +22,7 @@ pub struct CommandSuccess {
     pub stdout: String,
     pub stderr: String,
     pub duration: Duration,
+    pub exit_code: i32, // This field stores the exit code of the command to determine if it was successful or not, and whether or not there were any diffs.
 }
 
 impl CommandSuccess {
@@ -189,6 +190,7 @@ impl CommandLine {
                 cmd: self.clone(),
                 stdout,
                 stderr,
+                exit_code,
                 duration,
             }),
             Err(kind) => Err(CommandError {

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,6 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
+                _exit_code // This field is not used in this function, but it is part of the HelmResult struct.
             } = hr.as_ref();
             let result_str = hr.result_line();
 


### PR DESCRIPTION
**Description**

This PR introduces a feature to skip the Helm upgrade if no changes are detected. This is achieved by evaluating the detailed exit code returned by the helm diff command. The exit codes are interpreted as follows:

0.  No changes detected.
1.  Changes detected.
2.  Errors encountered.

This feature addresses the need to conditionally trigger Helm deployments based on whether there are actual changes, as discussed in [Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54).
.
**Changes Made**
Added the --detailed-exitcode flag to the helm diff command.
Evaluated the exit code to determine if changes were detected or if errors were encountered.
Updated the diff function to return a DiffResult with the appropriate exit code.

**Testing**

Ensure that the helm diff command returns the correct exit codes.
Verify that the upgrade is skipped if no changes are detected.
Confirm that changes are applied if the exit code indicates changes.
Handle errors appropriately based on the exit code.

**References**
[Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54)
[Issue #4 - helm-sops](https://github.com/camptocamp/helm-sops/issues/4)
