### PR TITLE
Feature/tm skip upgrade if unchanged + Linting

### DIFF
--- a/src/helm.rs
+++ b/src/helm.rs
@@ -446,7 +446,7 @@ pub async fn diff(
     tx.send(Message::InstallationResult(i_result)).await;
 
     // Return the exit code. Errors are no longer considered a failure and can be handled by the caller.
-    Ok(DiffResult { 
+    Ok(DiffResult {
         _exit_code: exit_code,
     })
 }

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -446,7 +446,9 @@ pub async fn diff(
     tx.send(Message::InstallationResult(i_result)).await;
 
     // Return the exit code. Errors are no longer considered a failure and can be handled by the caller.
-    Ok(DiffResult { _exit_code: exit_code })
+    Ok(DiffResult { 
+        _exit_code: exit_code 
+    })
 }
 
 /// Run the helm upgrade command.

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -447,7 +447,7 @@ pub async fn diff(
 
     // Return the exit code. Errors are no longer considered a failure and can be handled by the caller.
     Ok(DiffResult { 
-        _exit_code: exit_code 
+        _exit_code: exit_code,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,6 @@ mod duration;
 
 mod utils;
 
-
 /// An individual update
 #[derive(Clone, Debug)]
 pub struct Update {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,10 +193,10 @@ enum JobResult {
 
 // Asynchronously run a job based on the provided command.
 async fn run_job(
-    command: &Request, // The command to execute.
-    helm_repos: &HelmReposLock, // The helm repositories lock.
+    command: &Request,                // The command to execute.
+    helm_repos: &HelmReposLock,       // The helm repositories lock.
     installation: &Arc<Installation>, // The installation details.
-    tx: &MultiOutput, // The multi-output channel.
+    tx: &MultiOutput,                 // The multi-output channel.
 ) -> Result<JobResult> {
     match command {
         // Handle the Upgrade request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,8 +220,10 @@ async fn run_job(
             // Run the helm diff command.
             let diff_result = helm::diff(installation, helm_repos, tx).await?;
             // Return the diff result.
-            Ok(JobResult::Diff(helm::DiffResult { _exit_code: diff_result._exit_code }))
-        },
+            Ok(JobResult::Diff(helm::DiffResult {
+                _exit_code: diff_result._exit_code,
+            }))
+        }
         Request::Test { .. } => {
             helm::outdated(installation, helm_repos, tx).await?;
             helm::lint(installation, tx).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ where
 
 // Define the possible results of a job.
 enum JobResult {
-    Unit, // Represents a unit result.
+    Unit,                   // Represents a unit result.
     Diff(helm::DiffResult), // Represents a diff result.
 }
 

--- a/src/output/text.rs
+++ b/src/output/text.rs
@@ -216,7 +216,7 @@ fn process_message(msg: &Arc<Message>, state: &mut State) {
                 command,
                 result,
                 installation,
-                _exit_code // This field is not used in this function, but it is part of the HelmResult struct.
+                _exit_code, // This field is not used in this function, but it is part of the HelmResult struct.
             } = hr.as_ref();
             let result_str = hr.result_line();
 


### PR DESCRIPTION
**Description**

**This PR addresses cargo linting issues in the CI process for electronicarts/helmci**

This PR introduces a feature to skip the Helm upgrade if no changes are detected. This is achieved by evaluating the detailed exit code returned by the helm diff command. The exit codes are interpreted as follows:

0.  No changes detected.
1.  Changes detected.
2.  Errors encountered.

This feature addresses the need to conditionally trigger Helm deployments based on whether there are actual changes, as discussed in [Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54).
.
**Changes Made**
Added the --detailed-exitcode flag to the helm diff command.
Evaluated the exit code to determine if changes were detected or if errors were encountered.
Updated the diff function to return a DiffResult with the appropriate exit code.

**Testing**

Ensure that the helm diff command returns the correct exit codes.
Verify that the upgrade is skipped if no changes are detected.
Confirm that changes are applied if the exit code indicates changes.
Handle errors appropriately based on the exit code.

**References**
[Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54)
[Issue #4 - helm-sops](https://github.com/camptocamp/helm-sops/issues/4)
