### PR TITLE
"Rust auto-linting, revert config.yaml context"

### DIFF
--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: minikube
+context: dev-cluster
 locked: false

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -370,7 +370,12 @@ pub async fn template(
 }
 
 // The DiffResult struct is used to store the exit code of the diff command.
-pub enum DiffResult { NoChanges, Changes, Errors, Unknown }
+pub enum DiffResult {
+    NoChanges,
+    Changes,
+    Errors,
+    Unknown,
+}
 
 /// Run the helm diff command.
 pub async fn diff(


### PR DESCRIPTION
**Description**

**This PR addresses cargo linting issues in the CI process for electronicarts/helmci**

This PR introduces a feature to skip the Helm upgrade if no changes are detected. This is achieved by evaluating the detailed exit code returned by the helm diff command. The exit codes are interpreted as follows:

0.  No changes detected.
1.  Changes detected.
2.  Errors encountered.

This feature addresses the need to conditionally trigger Helm deployments based on whether there are actual changes, as discussed in [Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54).
.
**Changes Made**
Added the --detailed-exitcode flag to the helm diff command.
Evaluated the exit code to determine if changes were detected or if errors were encountered.
Updated the diff function to return a DiffResult with the appropriate exit code.

**Testing**

Ensure that the helm diff command returns the correct exit codes.
Verify that the upgrade is skipped if no changes are detected.
Confirm that changes are applied if the exit code indicates changes.
Handle errors appropriately based on the exit code.

**References**
[Issue #54 - helm-diff](https://github.com/databus23/helm-diff/issues/54)
[Issue #4 - helm-sops](https://github.com/camptocamp/helm-sops/issues/4)
