### PR TITLE
Implement -y / -n bypass cases.

### DIFF
--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: dev-cluster
+context: minikube
 locked: false

--- a/example/helm-values/envs/dev/dev-cluster/config.yaml
+++ b/example/helm-values/envs/dev/dev-cluster/config.yaml
@@ -1,2 +1,2 @@
-context: minikube
+context: dev-cluster
 locked: false

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,16 +438,17 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     // Extract the bypass_skip_upgrade_on_no_changes and bypass_assume_yes flags if the command is Upgrade
-    let (bypass_skip_upgrade_on_no_changes, bypass_assume_yes, bypass_assume_no) = if let Request::Upgrade {
-        bypass_skip_upgrade_on_no_changes,
-        yes,
-        no,
-    } = args.command
-    {
-        (bypass_skip_upgrade_on_no_changes, yes, no)
-    } else {
-        (false, false, false)
-    };
+    let (bypass_skip_upgrade_on_no_changes, bypass_assume_yes, bypass_assume_no) =
+        if let Request::Upgrade {
+            bypass_skip_upgrade_on_no_changes,
+            yes,
+            no,
+        } = args.command
+        {
+            (bypass_skip_upgrade_on_no_changes, yes, no)
+        } else {
+            (false, false, false)
+        };
 
     let output_types = if args.output.is_empty() {
         vec![OutputFormat::Text]


### PR DESCRIPTION
Description

**This PR addresses and addition commandline args case for the new -b commandline option.**

This PR introduces a feature to skip the Helm upgrade if no changes are detected. This is achieved by evaluating the detailed exit code returned by the helm diff command. The exit codes are interpreted as follows:

No changes detected.
Changes detected.
Errors encountered.
This feature addresses the need to conditionally trigger Helm deployments based on whether there are actual changes, as discussed in https://github.com/databus23/helm-diff/issues/54.
.
Changes Made
Added the --detailed-exitcode flag to the helm diff command.
Evaluated the exit code to determine if changes were detected or if errors were encountered.
Updated the diff function to return a DiffResult with the appropriate exit code.

Testing

Ensure that the helm diff command returns the correct exit codes.
Verify that the upgrade is skipped if no changes are detected.
Confirm that changes are applied if the exit code indicates changes.
Handle errors appropriately based on the exit code.

References
https://github.com/databus23/helm-diff/issues/54
https://github.com/camptocamp/helm-sops/issues/4