### PR TITLE
Remove UI prompt intererfered with TUI. Alter the way specific debug

### DIFF
--- a/src/helm.rs
+++ b/src/helm.rs
@@ -376,6 +376,9 @@ pub enum DiffResult {
     Errors,
     Unknown,
 }
+async fn log_debug_message(tx: &MultiOutput, message: &str) {
+    tx.send(Message::Log(log!(Level::DEBUG, message))).await;
+}
 
 /// Run the helm diff command.
 pub async fn diff(
@@ -423,24 +426,24 @@ pub async fn diff(
         i_result.exit_code = command_success.exit_code;
         match command_success.exit_code {
             0 => {
-                debug!("No changes detected!"); // Exit code 0 indicates no changes.
+                log_debug_message(tx, "No changes detected!").await; // Exit code 0 indicates no changes.
                 DiffResult::NoChanges
             }
             1 => {
-                debug!("Errors encountered!"); // Exit code 1 indicates errors.
+                log_debug_message(tx, "Errors encountered!").await; // Exit code 1 indicates errors.
                 DiffResult::Errors
             }
             2 => {
-                debug!("Changes detected!"); // Exit code 2 indicates changes.
+                log_debug_message(tx, "Changes detected!").await; // Exit code 2 indicates changes.
                 DiffResult::Changes
             }
             _ => {
-                debug!("Unknown exit code"); // Any other exit code is considered unknown.
+                log_debug_message(tx, "Unknown exit code").await; // Any other exit code is considered unknown.
                 DiffResult::Unknown
             }
         }
     } else {
-        debug!("Other exception encountered"); // If the command result is an error, return Unknown.
+        log_debug_message(tx, "Other exception encountered").await; // If the command result is an error, return Unknown.
         DiffResult::Unknown
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@
 extern crate lazy_static;
 
 use std::collections::HashMap;
-use std::io::{self};
 use std::path::PathBuf;
 use std::str::{self, FromStr};
 use std::sync::Arc;
@@ -211,23 +210,8 @@ async fn run_job(
                             helm::upgrade(installation, helm_repos, tx, true).await?;
                             helm::upgrade(installation, helm_repos, tx, false).await?;
                         }
-                        UpgradeControl::BypassAndAssumeNo => {
-                            // Do nothing, as bypass_assume_no is an implicit case
-                        }
-                        UpgradeControl::Normal => {
-                            print!("No changes detected. Upgrade anyway? (Y/n): ");
-
-                            let mut input = String::new();
-                            if let Err(e) = io::stdin().read_line(&mut input) {
-                                eprintln!("Failed to read input: {e}");
-                                return Err(anyhow::anyhow!("Failed to read input"));
-                            }
-                            let input = input.trim().to_lowercase();
-
-                            if input == "y" || input == "yes" || input.is_empty() {
-                                helm::upgrade(installation, helm_repos, tx, true).await?;
-                                helm::upgrade(installation, helm_repos, tx, false).await?;
-                            }
+                        UpgradeControl::BypassAndAssumeNo | UpgradeControl::Normal => {
+                            // Do nothing, as these are implicit or default cases
                         }
                     }
                 }


### PR DESCRIPTION
messages are written to avoid interfering with TUI mode / remove input prompts.